### PR TITLE
Fix calculating keyboard visibility in case if keyboard height is zero

### DIFF
--- a/Classes/IHKeyboardAvoiding.m
+++ b/Classes/IHKeyboardAvoiding.m
@@ -219,7 +219,7 @@ static NSNotification *_lastNotification;
                              [_updatedConstraintConstants removeAllObjects];
                          }];
     }
-    _isKeyboardVisible = CGRectContainsRect(CGRectMake(0, 0, screenSize.width, screenSize.height), keyboardFrame);
+    _isKeyboardVisible = CGRectIntersectsRect(CGRectMake(0, 0, screenSize.width, screenSize.height), keyboardFrame);
 }
 
 + (void)setAvoidingView:(UIView *)avoidingView {


### PR DESCRIPTION
CGRectContainsRect returns true if keyboard frame height is zero. So it causes wrong calculation of _isKeyboardVisible variable.
