### PR TITLE
Add carthage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.xcbkptlist
 Carthage
 *.xcscmblueprint
+
+.build

--- a/IHKeyboardAvoiding.xcodeproj/Configs/Project.xcconfig
+++ b/IHKeyboardAvoiding.xcodeproj/Configs/Project.xcconfig
@@ -1,0 +1,7 @@
+PRODUCT_NAME = $(TARGET_NAME)
+SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator
+MACOSX_DEPLOYMENT_TARGET = 10.10
+DYLIB_INSTALL_NAME_BASE = @rpath
+OTHER_SWIFT_FLAGS = -DXcode
+COMBINE_HIDPI_IMAGES = YES
+USE_HEADERMAP = NO

--- a/IHKeyboardAvoiding.xcodeproj/IHKeyboardAvoiding_Info.plist
+++ b/IHKeyboardAvoiding.xcodeproj/IHKeyboardAvoiding_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/IHKeyboardAvoiding.xcodeproj/project.pbxproj
+++ b/IHKeyboardAvoiding.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = __PBXFileRef_IHKeyboardAvoiding.xcodeproj/Configs/Project.xcconfig /* IHKeyboardAvoiding.xcodeproj/Configs/Project.xcconfig */;
 			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 			};
 			name = Release;
@@ -176,6 +177,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = __PBXFileRef_IHKeyboardAvoiding.xcodeproj/Configs/Project.xcconfig /* IHKeyboardAvoiding.xcodeproj/Configs/Project.xcconfig */;
 			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 			};
 			name = Debug;

--- a/IHKeyboardAvoiding.xcodeproj/project.pbxproj
+++ b/IHKeyboardAvoiding.xcodeproj/project.pbxproj
@@ -1,0 +1,207 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		__src_cc_ref_Sources/KeyboardAvoiding.swift /* KeyboardAvoiding.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/KeyboardAvoiding.swift /* KeyboardAvoiding.swift */; };
+		__src_cc_ref_Sources/KeyboardDismissingView.swift /* KeyboardDismissingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/KeyboardDismissingView.swift /* KeyboardDismissingView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		__PBXFileRef_IHKeyboardAvoiding.xcodeproj/Configs/Project.xcconfig /* IHKeyboardAvoiding.xcodeproj/Configs/Project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = IHKeyboardAvoiding.xcodeproj/Configs/Project.xcconfig; sourceTree = "<group>"; };
+		__PBXFileRef_Package.swift /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/KeyboardAvoiding.swift /* KeyboardAvoiding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardAvoiding.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/KeyboardDismissingView.swift /* KeyboardDismissingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardDismissingView.swift; sourceTree = "<group>"; };
+		"_____Product_IHKeyboardAvoiding" /* IHKeyboardAvoiding.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = IHKeyboardAvoiding.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		"___LinkPhase_IHKeyboardAvoiding" /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		"___RootGroup_" = {
+			isa = PBXGroup;
+			children = (
+				__PBXFileRef_Package.swift /* Package.swift */,
+				"_____Configs_" /* Configs */,
+				"_____Sources_" /* Sources */,
+				"____Products_" /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		"____Products_" /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				"_____Product_IHKeyboardAvoiding" /* IHKeyboardAvoiding.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		"_____Configs_" /* Configs */ = {
+			isa = PBXGroup;
+			children = (
+				__PBXFileRef_IHKeyboardAvoiding.xcodeproj/Configs/Project.xcconfig /* IHKeyboardAvoiding.xcodeproj/Configs/Project.xcconfig */,
+			);
+			name = Configs;
+			sourceTree = "<group>";
+		};
+		"_____Sources_" /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				"_______Group_IHKeyboardAvoiding" /* IHKeyboardAvoiding */,
+			);
+			name = Sources;
+			sourceTree = "<group>";
+		};
+		"_______Group_IHKeyboardAvoiding" /* IHKeyboardAvoiding */ = {
+			isa = PBXGroup;
+			children = (
+				__PBXFileRef_Sources/KeyboardAvoiding.swift /* KeyboardAvoiding.swift */,
+				__PBXFileRef_Sources/KeyboardDismissingView.swift /* KeyboardDismissingView.swift */,
+			);
+			name = IHKeyboardAvoiding;
+			path = Sources;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		"______Target_IHKeyboardAvoiding" /* IHKeyboardAvoiding */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = "_______Confs_IHKeyboardAvoiding" /* Build configuration list for PBXNativeTarget "IHKeyboardAvoiding" */;
+			buildPhases = (
+				CompilePhase_IHKeyboardAvoiding /* Sources */,
+				"___LinkPhase_IHKeyboardAvoiding" /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = IHKeyboardAvoiding;
+			productName = IHKeyboardAvoiding;
+			productReference = "_____Product_IHKeyboardAvoiding" /* IHKeyboardAvoiding.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		__RootObject_ /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 9999;
+			};
+			buildConfigurationList = "___RootConfs_" /* Build configuration list for PBXProject "IHKeyboardAvoiding" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = "___RootGroup_";
+			productRefGroup = "____Products_" /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				"______Target_IHKeyboardAvoiding" /* IHKeyboardAvoiding */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CompilePhase_IHKeyboardAvoiding /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				__src_cc_ref_Sources/KeyboardAvoiding.swift /* KeyboardAvoiding.swift in Sources */,
+				__src_cc_ref_Sources/KeyboardDismissingView.swift /* KeyboardDismissingView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		_ReleaseConf_IHKeyboardAvoiding /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				INFOPLIST_FILE = IHKeyboardAvoiding.xcodeproj/IHKeyboardAvoiding_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = IHKeyboardAvoiding;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+		"___DebugConf_IHKeyboardAvoiding" /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				INFOPLIST_FILE = IHKeyboardAvoiding.xcodeproj/IHKeyboardAvoiding_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = IHKeyboardAvoiding;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		"_____Release_" /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = __PBXFileRef_IHKeyboardAvoiding.xcodeproj/Configs/Project.xcconfig /* IHKeyboardAvoiding.xcodeproj/Configs/Project.xcconfig */;
+			buildSettings = {
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+			};
+			name = Release;
+		};
+		"_______Debug_" /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = __PBXFileRef_IHKeyboardAvoiding.xcodeproj/Configs/Project.xcconfig /* IHKeyboardAvoiding.xcodeproj/Configs/Project.xcconfig */;
+			buildSettings = {
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		"___RootConfs_" /* Build configuration list for PBXProject "IHKeyboardAvoiding" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				"_______Debug_" /* Debug */,
+				"_____Release_" /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		"_______Confs_IHKeyboardAvoiding" /* Build configuration list for PBXNativeTarget "IHKeyboardAvoiding" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				"___DebugConf_IHKeyboardAvoiding" /* Debug */,
+				_ReleaseConf_IHKeyboardAvoiding /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = __RootObject_ /* Project object */;
+}

--- a/IHKeyboardAvoiding.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/IHKeyboardAvoiding.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/IHKeyboardAvoiding.xcodeproj/xcshareddata/xcschemes/IHKeyboardAvoiding.xcscheme
+++ b/IHKeyboardAvoiding.xcodeproj/xcshareddata/xcschemes/IHKeyboardAvoiding.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0910"
+   LastUpgradeVersion = "9999"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,10 +14,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4C572D551E08C79F00BCBD99"
-               BuildableName = "KeyboardAvoiding.app"
-               BlueprintName = "KeyboardAvoiding"
-               ReferencedContainer = "container:KeyboardAvoiding.xcodeproj">
+               BlueprintIdentifier = "______Target_IHKeyboardAvoiding"
+               BuildableName = "IHKeyboardAvoiding.framework"
+               BlueprintName = "IHKeyboardAvoiding"
+               ReferencedContainer = "container:IHKeyboardAvoiding.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -30,15 +30,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4C572D551E08C79F00BCBD99"
-            BuildableName = "KeyboardAvoiding.app"
-            BlueprintName = "KeyboardAvoiding"
-            ReferencedContainer = "container:KeyboardAvoiding.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -53,16 +44,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4C572D551E08C79F00BCBD99"
-            BuildableName = "KeyboardAvoiding.app"
-            BlueprintName = "KeyboardAvoiding"
-            ReferencedContainer = "container:KeyboardAvoiding.xcodeproj">
+            BlueprintIdentifier = "______Target_IHKeyboardAvoiding"
+            BuildableName = "IHKeyboardAvoiding.framework"
+            BlueprintName = "IHKeyboardAvoiding"
+            ReferencedContainer = "container:IHKeyboardAvoiding.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -72,16 +62,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4C572D551E08C79F00BCBD99"
-            BuildableName = "KeyboardAvoiding.app"
-            BlueprintName = "KeyboardAvoiding"
-            ReferencedContainer = "container:KeyboardAvoiding.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/IHKeyboardAvoiding.xcodeproj/xcshareddata/xcschemes/xcschememanagement.plist
+++ b/IHKeyboardAvoiding.xcodeproj/xcshareddata/xcschemes/xcschememanagement.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>SchemeUserState</key>
+  <dict>
+    <key>IHKeyboardAvoiding.xcscheme</key>
+    <dict></dict>
+  </dict>
+  <key>SuppressBuildableAutocreation</key>
+  <dict></dict>
+</dict>
+</plist>

--- a/KeyboardAvoiding/KeyboardAvoiding.xcodeproj/xcshareddata/xcschemes/KeyboardAvoiding.xcscheme
+++ b/KeyboardAvoiding/KeyboardAvoiding.xcodeproj/xcshareddata/xcschemes/KeyboardAvoiding.xcscheme
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0910"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4C572D551E08C79F00BCBD99"
+               BuildableName = "KeyboardAvoiding.app"
+               BlueprintName = "KeyboardAvoiding"
+               ReferencedContainer = "container:KeyboardAvoiding.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4C572D551E08C79F00BCBD99"
+            BuildableName = "KeyboardAvoiding.app"
+            BlueprintName = "KeyboardAvoiding"
+            ReferencedContainer = "container:KeyboardAvoiding.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4C572D551E08C79F00BCBD99"
+            BuildableName = "KeyboardAvoiding.app"
+            BlueprintName = "KeyboardAvoiding"
+            ReferencedContainer = "container:KeyboardAvoiding.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4C572D551E08C79F00BCBD99"
+            BuildableName = "KeyboardAvoiding.app"
+            BlueprintName = "KeyboardAvoiding"
+            ReferencedContainer = "container:KeyboardAvoiding.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img alt="IHKeyboardAvoiding" src="https://github.com/IdleHandsApps/IHKeyboardAvoiding/blob/master/KeyboardAvoiding/KeyboardAvoiding/Assets.xcassets/AppIcon.appiconset/Icon-76.png" />
 </p>
 
-IHKeyboardAvoiding [![Language: Swift 4.0](https://img.shields.io/badge/Swift-4.0-orange.svg)](https://swift.org)
+IHKeyboardAvoiding [![Language: Swift 4.0](https://img.shields.io/badge/Swift-4.0-orange.svg)](https://swift.org) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 ------------------------------
 
 An elegant solution for keeping any UIView visible when the keyboard is being shown


### PR DESCRIPTION
I added `IHKeyboardAvoiding.xcodeproj` by `$swift package generate-xcodeproj` and enabled carthage build.
You can test the carthage build in two ways.
- `$ carthage build --no-skip-current --platform ios`.
- `$ carthage update --platform ios` using below `Cartfile`.
```
github "culumn/IHKeyboardAvoiding" "feature/carthage"
```