### PR TITLE
Fix issue with closure erasing constraints inconsistently

### DIFF
--- a/Sources/KeyboardAvoiding.swift
+++ b/Sources/KeyboardAvoiding.swift
@@ -23,6 +23,7 @@ import UIKit
     private(set) static var isKeyboardVisible = false
     private static var avoidingViewUsesAutoLayout = false
     private static var triggerViews = [UIView]()
+    private static var isChanging = false
     
     public static var buffer: CGFloat = 0.0
     public static var paddingForCurrentAvoidingView: CGFloat = 0.0
@@ -100,6 +101,7 @@ import UIKit
             animationDuration = 0.1
         }
         if isKeyBoardShowing {
+            isChanging = true
             for triggerView in self.triggerViews {
                 
                 //showing and docked
@@ -184,7 +186,9 @@ import UIKit
                                 transform = transform.translatedBy(x: 0, y: displacement)
                                 self.avoidingView!.transform = transform
                             }
-                        }, completion: { _ in })
+                        }, completion: { _ in
+                            isChanging = false
+                        })
                     }
                 }
                 if self.avoidingBlock != nil {
@@ -223,8 +227,10 @@ import UIKit
                         self.avoidingView!.transform = CGAffineTransform.identity
                     }
                 }, completion: {(_ finished: Bool) -> Void in
-                    self.updatedConstraints.removeAll()
-                    self.updatedConstraintConstants.removeAll()
+                    if !isChanging {
+                        self.updatedConstraints.removeAll()
+                        self.updatedConstraintConstants.removeAll()
+                    }
                 })
             }
             if self.avoidingBlock != nil {


### PR DESCRIPTION
This should fix #47. 
The closure can be executed while the avoidingView is moving, this results in the following flow:
- keyboard appears (action 1)
- avoidingView moves
- keyboard disappears (action 2)
- avoidingView returns to original position
- keyboard appears (action 3)
- avoidingView moves again
- closure for action 2 executes and removes constraints
- keyboard disappears (action 4)
- avoidingView doesn't move because the constraints are gone.