### PR TITLE
Change KeyboardDismissingView access to open

### DIFF
--- a/Sources/KeyboardDismissingView.swift
+++ b/Sources/KeyboardDismissingView.swift
@@ -8,12 +8,12 @@
 
 import UIKit
 
-@objc public class KeyboardDismissingView: UIView {
+@objc open class KeyboardDismissingView: UIView {
     
     public var dismissingBlock: (() -> Void)?
     public var touchEndedBlock: (() -> Void)?
     
-    override public func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+    override open func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesEnded(touches, with: event)
         
         let isDismissing = KeyboardDismissingView.resignAnyFirstResponder(self)


### PR DESCRIPTION
Hi, thanks for this nice little package. It helps me a lot as a Swift beginner to just avoid the keyboard problem :) However I found one little problem:

In order to subclass a class outside the current module, the access level needs to be "open"